### PR TITLE
chore(poseidon2): bump to latest noir version

### DIFF
--- a/poseidon2/src/bn254.nr
+++ b/poseidon2/src/bn254.nr
@@ -1,7 +1,7 @@
 mod consts;
 pub mod permutation;
-use dep::hash_utils;
-use dep::hash_utils::poseidon;
+use hash_utils;
+use hash_utils::poseidon;
 
 pub struct Poseidon2Bn254Config<let T: u32, let R: u32> {
     first_full_rc: [[Field; T]; 4],

--- a/poseidon2/src/bn254/permutation.nr
+++ b/poseidon2/src/bn254/permutation.nr
@@ -1,6 +1,6 @@
 use crate::bn254::consts;
 use crate::bn254::permute_bn254;
-use dep::hash_utils::poseidon;
+use hash_utils::poseidon;
 
 fn internal_2(state: [Field; 2]) -> [Field; 2] {
     let sum = state[0] + state[1];

--- a/poseidon2/src/lib.nr
+++ b/poseidon2/src/lib.nr
@@ -17,8 +17,7 @@ fn compute_merkle_root() {
     let index_bits = index.to_le_bits::<3>();
     let mut current = leaf;
     for i in 0..n {
-        let path_bit = index_bits[i] != 0;
-        let (hash_left, hash_right) = if path_bit {
+        let (hash_left, hash_right) = if index_bits[i] {
             (hash_path[i], current)
         } else {
             (current, hash_path[i])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates module import paths and a small test assertion loop to use boolean index bits directly; no algorithmic changes to the Poseidon2 permutation logic.
> 
> **Overview**
> Updates Poseidon2 BN254 code to use the new `hash_utils` import path (replacing `dep::hash_utils`) in `bn254.nr` and `bn254/permutation.nr`.
> 
> Adjusts the Merkle root test loop in `lib.nr` to treat `to_le_bits` output as booleans directly (removing the `!= 0` conversion) when selecting left/right hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cffa5519ab7ef4a0670f6a14968430735d6902b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->