### PR TITLE
feat: explicit support for noir beta.11 & beta.20

### DIFF
--- a/.github/workflows/noir-ci.yml
+++ b/.github/workflows/noir-ci.yml
@@ -1,0 +1,36 @@
+name: Noir CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: nargo test (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - v1.0.0-beta.11
+          - v1.0.0-beta.20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Test hash_utils
+        run: nargo test
+        working-directory: hash_utils
+      - name: Test poseidon
+        run: nargo test
+        working-directory: poseidon
+      - name: Test poseidon2
+        run: nargo test
+        working-directory: poseidon2

--- a/poseidon/src/bn254.nr
+++ b/poseidon/src/bn254.nr
@@ -3,8 +3,8 @@ mod default_perm;
 pub mod permutation;
 mod consts;
 
-use ::hash_utils;
-use ::hash_utils::poseidon;
+use hash_utils;
+use hash_utils::poseidon;
 
 pub struct PoseidonBn254Config<let T: u32, let RP: u32, let T1: u32> {
     first_full_rc: [[Field; T]; 4],

--- a/poseidon/src/bn254/default_perm.nr
+++ b/poseidon/src/bn254/default_perm.nr
@@ -1,5 +1,5 @@
-use ::hash_utils;
-use ::hash_utils::poseidon;
+use hash_utils;
+use hash_utils::poseidon;
 
 use crate::bn254::consts;
 

--- a/poseidon2/src/lib.nr
+++ b/poseidon2/src/lib.nr
@@ -17,7 +17,7 @@ fn compute_merkle_root() {
     let index_bits = index.to_le_bits::<3>();
     let mut current = leaf;
     for i in 0..n {
-        let (hash_left, hash_right) = if index_bits[i] {
+        let (hash_left, hash_right) = if (index_bits[i] as Field) == 1 {
             (hash_path[i], current)
         } else {
             (current, hash_path[i])


### PR DESCRIPTION
### Motivation

[Provekit](https://github.com/worldfnd/provekit) 1.0 is currently using noir lang `1.0.0-beta.11`, however on main, as well as useful zkpassport libraries (e.g. https://github.com/zk-passport/noir-ecdsa) use `1.0.0-beta.20`.

### Changes
Fix breaking changes between the two libraries and add an explicit CI check that will run tests against both noirlang versions.